### PR TITLE
Handle Status.Failure in ConnectionHandler when connected

### DIFF
--- a/core/src/main/scala/akka/wamp/client/ConnectionHandler.scala
+++ b/core/src/main/scala/akka/wamp/client/ConnectionHandler.scala
@@ -136,6 +136,16 @@ class ConnectionHandler(connector: ActorRef, address: URI, format: String, sslCo
       //    such as disconnection from router side
       connector ! Disconnected
       self ! PoisonPill
+
+    case sig @ Status.Failure(ex) =>
+      // NOTE:
+      // As documented for Sink.actorRef(), this signal is sent when
+      // the above AKKA STREAM is completed with a failure, such as
+      //
+      //   - akka.http.scaladsl.model.ws.PeerClosedConnectionException: Peer closed connection with code 1011 'internal error'
+      //
+      connector ! Disconnected
+      self ! PoisonPill
   }
 }
 


### PR DESCRIPTION
Currently the case Status.Failure is not handled in handleConnected receive method in ConnectionHandler.scala.

In case a failure occurs ( e.g. a server error ) it leaves the ConnectionHandler in a broken state without reporting the connector. 

This change sends a Disconnect to the connector and PoisonPill to self.

Resolves: #56 