### PR TITLE
Fix version number in maven repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Easy to download as dependency from [Maven central](https://search.maven.org/#se
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.github.angiolep" % "akka-wamp_2.12" % "0.15.2"
+  "com.github.angiolep" % "akka-wamp_2.12" % "0.15.1"
 )
 ```
 

--- a/docs/src/main/paradox/build.gradle
+++ b/docs/src/main/paradox/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-  compile 'com.github.angiolep:akka-wamp_2.12:0.15.2'
+  compile 'com.github.angiolep:akka-wamp_2.12:0.15.1'
   // ...
 }

--- a/docs/src/main/paradox/build.sbt
+++ b/docs/src/main/paradox/build.sbt
@@ -1,3 +1,3 @@
 libraryDependencies ++= Seq(
-  "com.github.angiolep" % "akka-wamp_2.12" % "0.15.2"
+  "com.github.angiolep" % "akka-wamp_2.12" % "0.15.1"
 )

--- a/docs/src/main/paradox/pom.xml
+++ b/docs/src/main/paradox/pom.xml
@@ -2,7 +2,7 @@
     <dependency>
         <groupId>com.github.angiolep</groupId>
         <artifactId>akka-wamp_2.12</artifactId>
-        <version>0.15.2</version>
+        <version>0.15.1</version>
     </dependency>
     <!-- .... -->
 </dependencies>


### PR DESCRIPTION
When I try to work wamp in seed project, it causes failure by cannot finding library.
I checked mvn repo, and there were 0.15.1, no 0.15.2.
If it will not be updated soon, how about fix the document for guide?

Thanks.